### PR TITLE
Update script.js for Sketch v45+

### DIFF
--- a/Navigate Artboards.sketchplugin/Contents/Sketch/script.js
+++ b/Navigate Artboards.sketchplugin/Contents/Sketch/script.js
@@ -1,10 +1,8 @@
-var onRun = function(doc, direction) {
-  var page = doc.currentPage()
-
-  var max = page.artboards().count()
-  var currentArtboard = page.artboards().indexOfObject(page.currentArtboard())
-
-  page.deselectAllLayers()
+  if(page.deselectAllLayers){
+    page.deselectAllLayers();
+  }else{
+    page.changeSelectionBySelectingLayers_([]);
+  }
 
   var newSelection = currentArtboard + direction
 
@@ -18,6 +16,13 @@ var onRun = function(doc, direction) {
   var artboard = page.artboards()[newSelection]
 
   // Select and center the new artboard
+  if (page.select_byExpandingSelection) {
+    page.select_byExpandingSelection(true, true);
+  } else {
+    page.select_byExtendingSelection(true, true);
+  }
+
+
   artboard.select_byExpandingSelection(true, false)
   var view = doc.currentView()
   var viewRect = artboard.rect();
@@ -33,4 +38,5 @@ var previousArtboard = function(context) {
   var doc = context.document
   onRun(doc, -1)
 };
+
 

--- a/Navigate Artboards.sketchplugin/Contents/Sketch/script.js
+++ b/Navigate Artboards.sketchplugin/Contents/Sketch/script.js
@@ -1,3 +1,9 @@
+var onRun = function(doc, direction) {
+  var page = doc.currentPage()
+
+  var max = page.artboards().count()
+  var currentArtboard = page.artboards().indexOfObject(page.currentArtboard())
+
   if(page.deselectAllLayers){
     page.deselectAllLayers();
   }else{
@@ -38,5 +44,3 @@ var previousArtboard = function(context) {
   var doc = context.document
   onRun(doc, -1)
 };
-
-

--- a/Navigate Artboards.sketchplugin/Contents/Sketch/script.js
+++ b/Navigate Artboards.sketchplugin/Contents/Sketch/script.js
@@ -28,7 +28,6 @@ var onRun = function(doc, direction) {
     page.select_byExtendingSelection(true, true);
   }
 
-
   artboard.select_byExpandingSelection(true, false)
   var view = doc.currentView()
   var viewRect = artboard.rect();


### PR DESCRIPTION
Choked on `page.deselectAllLayers` and `select:byExpandingSelection` gives a 'deprecated' warning.